### PR TITLE
PEP8 formatting

### DIFF
--- a/osm2geojson/helpers.py
+++ b/osm2geojson/helpers.py
@@ -1,17 +1,20 @@
-from functools import wraps
-import requests
 import codecs
-import urllib
-from time import sleep
 import os
+import urllib
+from functools import wraps
+from time import sleep
+
+import requests
 
 OVERPASS = "https://overpass-api.de/api/interpreter/"
 dirname = os.path.dirname(os.path.dirname(__file__))
+
 
 def read_data_file(name):
     path = os.path.join(dirname, 'tests/data', name)
     with codecs.open(path, 'r', encoding='utf-8') as data:
         return data.read()
+
 
 def retry_request_multi(max_retries):
     def retry(func):
@@ -31,6 +34,7 @@ def retry_request_multi(max_retries):
         return wrapper
     return retry
 
+
 @retry_request_multi(5)
 def overpass_call(query):
     encoded = urllib.parse.quote(query.encode("utf-8"), safe='~()*!.\'')
@@ -38,5 +42,6 @@ def overpass_call(query):
                       data="data={}".format(encoded),
                       headers={"Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"})
     if not r.status_code == 200:
-        raise requests.exceptions.HTTPError('Overpass server respond with status '+str(r.status_code))
+        raise requests.exceptions.HTTPError(
+            'Overpass server respond with status '+str(r.status_code))
     return r.text

--- a/osm2geojson/main.py
+++ b/osm2geojson/main.py
@@ -1,14 +1,15 @@
-from .parse_xml import parse as parse_xml
-from shapely.ops import cascaded_union, linemerge
-from shapely.geometry import (
-    mapping, Polygon, Point, LineString, MultiLineString, MultiPolygon, GeometryCollection
-)
-from shapely.geometry.polygon import orient
+import json
+import logging
+import os
 import traceback
 from pprint import pformat
-import logging
-import json
-import os
+
+from shapely.geometry import (GeometryCollection, LineString, MultiLineString,
+                              MultiPolygon, Point, Polygon, mapping)
+from shapely.geometry.polygon import orient
+from shapely.ops import cascaded_union, linemerge
+
+from .parse_xml import parse as parse_xml
 
 logger = logging.getLogger(__name__)
 dirname = os.path.dirname(__file__)
@@ -100,7 +101,7 @@ def _json2shapes(data, filter_used_refs=True, log_level='ERROR'):
     return filtered_shapes
 
 
-def element_to_shape(el, refs_index = None):
+def element_to_shape(el, refs_index=None):
     t = el['type']
     if t == 'node':
         return node_to_shape(el)
@@ -150,7 +151,7 @@ def node_to_shape(node):
     }
 
 
-def get_element_props(el, keys = ['type', 'id', 'tags']):
+def get_element_props(el, keys=['type', 'id', 'tags']):
     props = {}
     for key in keys:
         if key in el:
@@ -171,14 +172,14 @@ def convert_coords_to_lists(coords):
     return new_coords
 
 
-def shape_to_feature(g, props = {}):
+def shape_to_feature(g, props={}):
     # shapely returns tuples (we need lists)
-    g =  mapping(g)
+    g = mapping(g)
     g['coordinates'] = convert_coords_to_lists(g['coordinates'])
     return {
         "type": "Feature",
         'properties': props,
-        "geometry":g
+        "geometry": g
     }
 
 
@@ -196,7 +197,7 @@ def fix_invalid_polygon(p):
     return p
 
 
-def way_to_shape(way, refs_index = {}):
+def way_to_shape(way, refs_index={}):
     coords = []
 
     if 'center' in way:
@@ -309,6 +310,7 @@ def is_geometry_polygon(node):
         return not is_exception(node)
     else:
         return False
+
 
 def is_geometry_polygon_without_exceptions(node):
     tags = node['tags']
@@ -431,7 +433,7 @@ def multipolygon_relation_to_shape(rel, refs_index):
 
     multipolygon = fix_invalid_polygon(multipolygon)
     multipolygon = to_multipolygon(multipolygon)
-    multipolygon = orient_multipolygon(multipolygon) # do we need this?
+    multipolygon = orient_multipolygon(multipolygon)  # do we need this?
 
     return {
         'shape': multipolygon,
@@ -483,7 +485,7 @@ def _convert_lines_to_multipolygon(lines):
     return to_multipolygon(poly)
 
 
-def convert_ways_to_multipolygon(outer, inner = []):
+def convert_ways_to_multipolygon(outer, inner=[]):
     if len(outer) < 1:
         # throw exception
         warning('Ways not found')

--- a/osm2geojson/parse_xml.py
+++ b/osm2geojson/parse_xml.py
@@ -1,6 +1,8 @@
 import xml.etree.ElementTree as ElementTree
+
 default_types = ['node', 'way', 'relation', 'member', 'nd']
 optional_meta_fields = ['timestamp', 'version:int', 'changeset:int', 'user', 'uid:int']
+
 
 def parse_key(key):
     t = 'string'
@@ -8,6 +10,7 @@ def parse_key(key):
     if len(parts) > 1:
         t = parts[1]
     return parts[0], t
+
 
 def to_type(v, t):
     if t == 'string':
@@ -18,13 +21,15 @@ def to_type(v, t):
         return float(v)
     return v
 
-def with_meta_fields(fields = []):
+
+def with_meta_fields(fields=[]):
     for field in optional_meta_fields:
         if field not in fields:
             fields.append(field)
     return fields
 
-def copy_fields(node, base, optional = []):
+
+def copy_fields(node, base, optional=[]):
     obj = {}
     for key in base:
         key, t = parse_key(key)
@@ -37,6 +42,7 @@ def copy_fields(node, base, optional = []):
             obj[key] = to_type(node.attrib[key], t)
     return obj
 
+
 def filter_items_by_type(items, types):
     filtered = []
     for i in items:
@@ -44,11 +50,13 @@ def filter_items_by_type(items, types):
             filtered.append(i)
     return filtered
 
+
 def tags_to_obj(tags):
     obj = {}
     for tag in tags:
         obj[tag['k']] = tag['v']
     return obj
+
 
 def parse_bounds(node):
     return copy_fields(node, [
@@ -58,6 +66,7 @@ def parse_bounds(node):
         'maxlon:float'
     ])
 
+
 def parse_count(node):
     bounds, tags, _empty, unhandled = parse_xml_node(node, [])
     item = copy_fields(node, ['id:int'])
@@ -66,11 +75,14 @@ def parse_count(node):
         item['tags'] = tags_to_obj(tags)
     return item
 
+
 def parse_tag(node):
     return copy_fields(node, ['k', 'v'])
 
+
 def parse_nd(node):
     return copy_fields(node, [], ['ref:int', 'lat:float', 'lon:float'])
+
 
 def parse_node(node):
     bounds, tags, items, unhandled = parse_xml_node(node)
@@ -85,6 +97,7 @@ def parse_node(node):
     if len(tags) > 0:
         item['tags'] = tags_to_obj(tags)
     return item
+
 
 def parse_way(node):
     bounds, tags, nds, unhandled = parse_xml_node(node, ['nd'])
@@ -106,6 +119,7 @@ def parse_way(node):
         way['nodes'] = nodes
     return way
 
+
 def parse_relation(node):
     bounds, tags, members, unhandled = parse_xml_node(node, ['member'])
 
@@ -118,6 +132,7 @@ def parse_relation(node):
     if len(tags) > 0:
         relation['tags'] = tags_to_obj(tags)
     return relation
+
 
 def format_ojson(elements, unhandled):
     version = 0.6
@@ -152,6 +167,7 @@ def format_ojson(elements, unhandled):
 
     return item
 
+
 def parse(xml_str):
     root = ElementTree.fromstring(xml_str)
     if not root.tag == 'osm':
@@ -161,6 +177,7 @@ def parse(xml_str):
     bounds, tags, elements, unhandled = parse_xml_node(root, ['node', 'way', 'relation', 'count'])
     unhandled.append(root)
     return format_ojson(elements, unhandled)
+
 
 def parse_node_type(node, node_type):
     if node_type == 'bounds':
@@ -188,7 +205,8 @@ def parse_node_type(node, node_type):
         print('Unhandled node type', node_type)
         return None
 
-def parse_xml_node(root, node_types = default_types):
+
+def parse_xml_node(root, node_types=default_types):
     bounds = None
     count = None
     tags = []


### PR DESCRIPTION
I was looking at the code to work on some other PRs, and was wondering if you would be willing to format the code to [PEP8](https://www.python.org/dev/peps/pep-0008/) standards? I think this would make it easier for others to work on and understand the library as well.

This PR contains no actual changes to code function, only whitespace changes and import reordering.