### PR TITLE
Raise exception if relation cannot be converted to shape

### DIFF
--- a/osm2geojson/main.py
+++ b/osm2geojson/main.py
@@ -384,8 +384,7 @@ def relation_to_shape(rel, refs_index, area_keys: Optional[dict] = None, polygon
         else:
             return multiline_realation_to_shape(rel, refs_index)
     except Exception:
-        traceback.print_exc()
-        error('Failed to convert relation to shape', pformat(rel))
+        logger.exception(f'Failed to convert relation to shape: \n {pformat(rel)}')
 
 
 def multiline_realation_to_shape(

--- a/osm2geojson/main.py
+++ b/osm2geojson/main.py
@@ -385,6 +385,7 @@ def relation_to_shape(rel, refs_index, area_keys: Optional[dict] = None, polygon
             return multiline_realation_to_shape(rel, refs_index)
     except Exception:
         logger.exception(f'Failed to convert relation to shape: \n {pformat(rel)}')
+        raise
 
 
 def multiline_realation_to_shape(


### PR DESCRIPTION
I ran into an issue when using osm2geojson with a workflow orchestrator to convert a batch of relations into geojsons. When osm2geojson failed, it would not raise an exception, leading my script to believe that the conversion was successful. This PR raises an exception rather than logging an error in this case, signalling to downstream code that the conversion was not successful.

I have uploaded an example JSON relation [here](https://gist.github.com/jacobwhall/aad295696719e69afea042d90a621eb2) that reproduces this issue. If you'd like an example in this thread, I can attempt to create a more concise one. Here is the code from this example:
```python
import json
import osm2geojson

f = open("relation.json")
data = json.load(f)

# this should raise an exception
osm2geojson.json2shapes(data)
```

Thanks for your work on this repository, it has been immensely helpful to my team!

@sgoodm