### PR TITLE
publish a wheel

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*

--- a/release.sh
+++ b/release.sh
@@ -2,5 +2,5 @@ set -e
 ./lint.sh
 python -m unittest discover
 rm -rf dist
-python setup.py sdist
+python -m build
 twine upload dist/*


### PR DESCRIPTION
Build and publish a wheel, rather than making every user do it for themselves.

Among other reasons this would protect users from events like #49: if no-one has to build from the source themselves, then that process cannot go wrong