### PR TITLE
Blacklist polygon rules should be treated as "all" in whitelist pass

### DIFF
--- a/osm2geojson/main.py
+++ b/osm2geojson/main.py
@@ -431,7 +431,14 @@ def is_geometry_polygon_without_exceptions(node, polygon_features: Optional[list
     # Second pass: check whitelists and "all" rules
     for rule in polygon_features:
         if rule["key"] in tags:
-            if rule["polygon"] == "all" or rule["polygon"] == "blacklist":
+            if rule["polygon"] == "blacklist":
+                blacklist_whitelisted = False
+                for rule2 in polygon_features:
+                    if rule["key"] == rule2["key"] and rule2["polygon"] == "whitelist":
+                        blacklist_whitelisted = True
+                if not blacklist_whitelisted:
+                    return True
+            if rule["polygon"] == "all":
                 return True
             if rule["polygon"] == "whitelist" and tags[rule["key"]] in rule["values"]:
                 return True

--- a/osm2geojson/main.py
+++ b/osm2geojson/main.py
@@ -431,7 +431,7 @@ def is_geometry_polygon_without_exceptions(node, polygon_features: Optional[list
     # Second pass: check whitelists and "all" rules
     for rule in polygon_features:
         if rule["key"] in tags:
-            if rule["polygon"] == "all":
+            if rule["polygon"] == "all" or rule["polygon"] == "blacklist":
                 return True
             if rule["polygon"] == "whitelist" and tags[rule["key"]] in rule["values"]:
                 return True

--- a/tests/test_polygon_logic.py
+++ b/tests/test_polygon_logic.py
@@ -191,6 +191,16 @@ class TestIsGeometryPolygonWithoutExceptions(unittest.TestCase):
         result = is_geometry_polygon_without_exceptions(node)
         self.assertFalse(result, "Element with blacklisted tag should NOT be a polygon")
 
+    def test_non_blacklist_match(self):
+        """
+        Test that non-blacklisted values for blacklist rules are correctly identified as polygons.
+        Example: natural=water (natural has a blacklist without water in it)
+        Should be a polygon.
+        """
+        node = {"tags": {"natural": "water"}}
+        result = is_geometry_polygon_without_exceptions(node)
+        self.assertTrue(result, "Element with non matching blacklisted tag should be a polygon")
+
     def test_no_relevant_tags(self):
         """
         Test default behavior when element has no tags matching any rules.


### PR DESCRIPTION
My understanding of blacklist rules is they  are effectively "all with exceptions". The exceptions are handled in the first blacklist pass, so the second pass should treat them as all.

Example that should be a polygon (natural=water) https://www.openstreetmap.org/way/9641206

`there is a natural=* tag and its value is not any of: no, coastline, cliff, ridge, arete nor tree_row;`
https://wiki.openstreetmap.org/wiki/Overpass_turbo/Polygon_Features